### PR TITLE
Instrumentation is now always on

### DIFF
--- a/lib/cashier/railtie.rb
+++ b/lib/cashier/railtie.rb
@@ -1,9 +1,5 @@
 module Cashier
   class Railtie < ::Rails::Railtie
     config.cashier = Cashier
-
-    initializer "cashier.active_support.cache.instrumentation" do |app|
-      ActiveSupport::Cache::Store.instrument = true
-    end
   end
 end


### PR DESCRIPTION
Fixed:
`DEPRECATION WARNING: ActiveSupport::Cache.instrument= is deprecated and will be removed in Rails 5. Instrumentation is now always on so you can safely stop using it`